### PR TITLE
[bugfix] warped_moving_out has to be casted to correct dtype

### DIFF
--- a/src/unigradicon/__init__.py
+++ b/src/unigradicon/__init__.py
@@ -273,6 +273,7 @@ def main():
     itk.transformwrite([phi_AB], args.transform_out)
 
     if args.warped_moving_out:
+        moving = itk.CastImageFilter[type(moving), itk.Image[itk.F, 3]].New()(moving)
         interpolator = itk.LinearInterpolateImageFunction.New(moving)
         warped_moving_image = itk.resample_image_filter(
                 moving,


### PR DESCRIPTION
I encountered this bug while working with off-the-shelf NIFTI images:

```
unigradicon-register --fixed=images/TP0_1_0000.nii.gz --moving=images/TP1_1_0000.nii.gz --transform_out=transformations/TP1_1.hdf5 --warped_moving_out=imagesTr_reg/TP1_1_0000.nii.gz --io_iterations 1 --fixed_modality "ct" --moving_modality "ct"

ICONLoss(all_loss=tensor(1.2213, device='cuda:0', grad_fn=<AddBackward0>), inverse_consistency_loss=tensor(0.0160, device='cuda:0', grad_fn=<AddBackward0>), similarity_loss=tensor(1.1973, device='cuda:0', grad_fn=<AddBackward0>), transform_magnitude=tensor(0.0005, device='cuda:0', grad_fn=<MeanBackward0>), flips=tensor(739., device='cuda:0'))
Traceback (most recent call last):
  File "/home/user/miniconda3/bin/unigradicon-register", line 8, in <module>
    sys.exit(main())
  File "/home/user/projects/uniGradICON/src/unigradicon/__init__.py", line 276, in main
    interpolator = itk.LinearInterpolateImageFunction.New(moving)
  File "/home/user/miniconda3/lib/python3.10/site-packages/itk/support/template_class.py", line 734, in New
    raise itk.TemplateTypeError(self, input_type)
itk.support.extras.TemplateTypeError: itk.LinearInterpolateImageFunction is not wrapped for input type `None`.

To limit the size of the package, only a limited number of
types are available in ITK Python. To print the supported
types, run the following command in your python environment:

    itk.LinearInterpolateImageFunction.GetTypes()

Possible solutions:
* If you are an application user:
** Convert your input image into a supported format (see below).
** Contact developer to report the issue.
* If you are an application developer, force input images to be
loaded in a supported pixel type.

    e.g.: instance = itk.LinearInterpolateImageFunction[itk.Image[itk.SS,2], itk.D].New(my_input)

* (Advanced) If you are an application developer, build ITK Python yourself and
turned to `ON` the corresponding CMake option to wrap the pixel type or image
dimension you need. When configuring ITK with CMake, you can set
`ITK_WRAP_${type}` (replace ${type} with appropriate pixel type such as
`double`). If you need to support images with 4 or 5 dimensions, you can add
these dimensions to the list of dimensions in the CMake variable
`ITK_WRAP_IMAGE_DIMS`.

Supported input types:

itk.Image[itk.SS,2]
itk.Image[itk.UC,2]
itk.Image[itk.US,2]
itk.Image[itk.F,2]
itk.Image[itk.D,2]
itk.Image[itk.Vector[itk.F,2],2]
itk.Image[itk.CovariantVector[itk.F,2],2]
itk.Image[itk.RGBPixel[itk.UC],2]
itk.Image[itk.RGBAPixel[itk.UC],2]
itk.Image[itk.SS,3]
itk.Image[itk.UC,3]
itk.Image[itk.US,3]
itk.Image[itk.F,3]
itk.Image[itk.D,3]
itk.Image[itk.Vector[itk.F,3],3]
itk.Image[itk.CovariantVector[itk.F,3],3]
itk.Image[itk.RGBPixel[itk.UC],3]
itk.Image[itk.RGBAPixel[itk.UC],3]
itk.Image[itk.SS,4]
itk.Image[itk.UC,4]
itk.Image[itk.US,4]
itk.Image[itk.F,4]
itk.Image[itk.D,4]
itk.Image[itk.Vector[itk.F,4],4]
itk.Image[itk.CovariantVector[itk.F,4],4]
itk.Image[itk.RGBPixel[itk.UC],4]
itk.Image[itk.RGBAPixel[itk.UC],4]
``` 

The added line makes sure that the moving image is cast correctly before the warp. 