### PR TITLE
Add multiGradICON

### DIFF
--- a/.github/workflows/gpu-test-action.yml
+++ b/.github/workflows/gpu-test-action.yml
@@ -1,0 +1,31 @@
+name: gpu-tests
+
+on:
+  pull_request:
+  push:
+    branches: [dev, main]
+
+jobs:
+  test-linux:
+    runs-on: [self-hosted, linux]
+    strategy:
+      max-parallel: 5
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        pip install -r requirements.txt
+        
+        pip install -e .
+
+    - name: fast test with unittest
+      run: |
+        python -m unittest -k CPU
+    - name: GPU test with unittest
+      run: |
+        python -m unittest discover

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+icon_registration>=1.1.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ packages = find:
 python_requires = >=3.7
 
 install_requires = 
-    icon_registration>=1.1.4
+    icon_registration>=1.1.5
 
 [options.packages.find]
 where = src

--- a/tests/test_command_arguments.py
+++ b/tests/test_command_arguments.py
@@ -1,0 +1,104 @@
+import itk
+import numpy as np
+import unittest
+import icon_registration.test_utils
+
+import subprocess
+import os
+
+
+class TestCommandInterface(unittest.TestCase):
+    def __init__(self, methodName: str = "runTest") -> None:
+        super().__init__(methodName)
+        icon_registration.test_utils.download_test_data()
+        self.test_data_dir = icon_registration.test_utils.TEST_DATA_DIR
+        self.test_temp_dir = f"{self.test_data_dir}/temp"
+        os.makedirs(self.test_temp_dir, exist_ok=True)
+
+    def test_register_unigradicon_inference(self):
+        subprocess.run([
+            "unigradicon-register",
+            "--fixed", f"{self.test_data_dir}/lung_test_data/copd1_highres_EXP_STD_COPD_img.nii.gz",
+            "--fixed_modality", "ct",
+            "--fixed_segmentation", f"{self.test_data_dir}/lung_test_data/copd1_highres_EXP_STD_COPD_label.nii.gz",
+            "--moving", f"{self.test_data_dir}/lung_test_data/copd1_highres_INSP_STD_COPD_img.nii.gz",
+            "--moving_modality", "ct",
+            "--moving_segmentation", f"{self.test_data_dir}/lung_test_data/copd1_highres_INSP_STD_COPD_label.nii.gz",
+            "--transform_out", f"{self.test_temp_dir}/transform.hdf5",
+            "--io_iterations", "None"
+        ])
+
+        # load transform
+        phi_AB = itk.transformread(f"{self.test_temp_dir}/transform.hdf5")[0]
+
+        assert isinstance(phi_AB, itk.CompositeTransform)
+
+        insp_points = icon_registration.test_utils.read_copd_pointset(
+            str(
+                icon_registration.test_utils.TEST_DATA_DIR
+                / "lung_test_data/copd1_300_iBH_xyz_r1.txt"
+            )
+        )
+        exp_points = icon_registration.test_utils.read_copd_pointset(
+            str(
+                icon_registration.test_utils.TEST_DATA_DIR
+                / "lung_test_data/copd1_300_eBH_xyz_r1.txt"
+            )
+        )
+
+        dists = []
+        for i in range(len(insp_points)):
+            px, py = (
+                insp_points[i],
+                np.array(phi_AB.TransformPoint(tuple(exp_points[i]))),
+            )
+            dists.append(np.sqrt(np.sum((px - py) ** 2)))
+        print(np.mean(dists))
+        self.assertLess(np.mean(dists), 2.1)
+
+        # remove temp file
+        os.remove(f"{self.test_temp_dir}/transform.hdf5")
+
+    def test_register_unigradicon_io(self):
+        subprocess.run([
+            "unigradicon-register",
+            "--fixed", f"{self.test_data_dir}/lung_test_data/copd1_highres_EXP_STD_COPD_img.nii.gz",
+            "--fixed_modality", "ct",
+            "--fixed_segmentation", f"{self.test_data_dir}/lung_test_data/copd1_highres_EXP_STD_COPD_label.nii.gz",
+            "--moving", f"{self.test_data_dir}/lung_test_data/copd1_highres_INSP_STD_COPD_img.nii.gz",
+            "--moving_modality", "ct",
+            "--moving_segmentation", f"{self.test_data_dir}/lung_test_data/copd1_highres_INSP_STD_COPD_label.nii.gz",
+            "--transform_out", f"{self.test_temp_dir}/transform.hdf5"
+        ])
+
+        # load transform
+        phi_AB = itk.transformread(f"{self.test_temp_dir}/transform.hdf5")[0]
+
+        assert isinstance(phi_AB, itk.CompositeTransform)
+
+        insp_points = icon_registration.test_utils.read_copd_pointset(
+            str(
+                icon_registration.test_utils.TEST_DATA_DIR
+                / "lung_test_data/copd1_300_iBH_xyz_r1.txt"
+            )
+        )
+        exp_points = icon_registration.test_utils.read_copd_pointset(
+            str(
+                icon_registration.test_utils.TEST_DATA_DIR
+                / "lung_test_data/copd1_300_eBH_xyz_r1.txt"
+            )
+        )
+
+        dists = []
+        for i in range(len(insp_points)):
+            px, py = (
+                insp_points[i],
+                np.array(phi_AB.TransformPoint(tuple(exp_points[i]))),
+            )
+            dists.append(np.sqrt(np.sum((px - py) ** 2)))
+        print(np.mean(dists))
+        self.assertLess(np.mean(dists), 1.5)
+
+        # remove temp file
+        os.remove(f"{self.test_temp_dir}/transform.hdf5")
+        

--- a/tests/test_command_arguments.py
+++ b/tests/test_command_arguments.py
@@ -5,6 +5,7 @@ import icon_registration.test_utils
 
 import subprocess
 import os
+import torch
 
 
 class TestCommandInterface(unittest.TestCase):
@@ -14,6 +15,7 @@ class TestCommandInterface(unittest.TestCase):
         self.test_data_dir = icon_registration.test_utils.TEST_DATA_DIR
         self.test_temp_dir = f"{self.test_data_dir}/temp"
         os.makedirs(self.test_temp_dir, exist_ok=True)
+        self.device = torch.cuda.current_device()
 
     def test_register_unigradicon_inference(self):
         subprocess.run([
@@ -58,8 +60,8 @@ class TestCommandInterface(unittest.TestCase):
 
         # remove temp file
         os.remove(f"{self.test_temp_dir}/transform.hdf5")
-
-    def test_register_unigradicon_io(self):
+    
+    def test_register_multigradicon_inference(self):
         subprocess.run([
             "unigradicon-register",
             "--fixed", f"{self.test_data_dir}/lung_test_data/copd1_highres_EXP_STD_COPD_img.nii.gz",
@@ -68,7 +70,9 @@ class TestCommandInterface(unittest.TestCase):
             "--moving", f"{self.test_data_dir}/lung_test_data/copd1_highres_INSP_STD_COPD_img.nii.gz",
             "--moving_modality", "ct",
             "--moving_segmentation", f"{self.test_data_dir}/lung_test_data/copd1_highres_INSP_STD_COPD_label.nii.gz",
-            "--transform_out", f"{self.test_temp_dir}/transform.hdf5"
+            "--transform_out", f"{self.test_temp_dir}/transform.hdf5",
+            "--io_iterations", "None",
+            "--model", "multigradicon"
         ])
 
         # load transform
@@ -97,8 +101,10 @@ class TestCommandInterface(unittest.TestCase):
             )
             dists.append(np.sqrt(np.sum((px - py) ** 2)))
         print(np.mean(dists))
-        self.assertLess(np.mean(dists), 1.5)
+        self.assertLess(np.mean(dists), 3.8)
 
         # remove temp file
         os.remove(f"{self.test_temp_dir}/transform.hdf5")
+
+        
         

--- a/tests/test_requirements_sync.py
+++ b/tests/test_requirements_sync.py
@@ -12,7 +12,7 @@ class TestImports(unittest.TestCase):
         parent_dir = current_dir[: current_dir.rfind(path.sep)]
 
         with open(parent_dir + "/requirements.txt") as f:
-            requirements_txt = f.read()
+            requirements_txt = "\n" + f.read()
         requirements_cfg = configparser.ConfigParser()
         requirements_cfg.read(parent_dir + "/setup.cfg")
         requirements_cfg = requirements_cfg["options"]["install_requires"]

--- a/tests/test_requirements_sync.py
+++ b/tests/test_requirements_sync.py
@@ -1,0 +1,19 @@
+import unittest
+
+
+class TestImports(unittest.TestCase):
+
+    def test_requirements_match_cfg(self):
+        from inspect import getsourcefile
+        import os.path as path, sys
+        import configparser
+
+        current_dir = path.dirname(path.abspath(getsourcefile(lambda: 0)))
+        parent_dir = current_dir[: current_dir.rfind(path.sep)]
+
+        with open(parent_dir + "/requirements.txt") as f:
+            requirements_txt = "\n" + f.read()
+        requirements_cfg = configparser.ConfigParser()
+        requirements_cfg.read(parent_dir + "/setup.cfg")
+        requirements_cfg = requirements_cfg["options"]["install_requires"] + "\n"
+        self.assertEqual(requirements_txt, requirements_cfg)

--- a/tests/test_requirements_sync.py
+++ b/tests/test_requirements_sync.py
@@ -12,8 +12,8 @@ class TestImports(unittest.TestCase):
         parent_dir = current_dir[: current_dir.rfind(path.sep)]
 
         with open(parent_dir + "/requirements.txt") as f:
-            requirements_txt = "\n" + f.read()
+            requirements_txt = f.read()
         requirements_cfg = configparser.ConfigParser()
         requirements_cfg.read(parent_dir + "/setup.cfg")
-        requirements_cfg = requirements_cfg["options"]["install_requires"] + "\n"
+        requirements_cfg = requirements_cfg["options"]["install_requires"]
         self.assertEqual(requirements_txt, requirements_cfg)


### PR DESCRIPTION
1. Enable user to specify which model unigradicon-register should use. We currently supports two models unigradicon and multigradicon.
2. Add support for different similarity measures (e.g. LNCC, Squared LNCC, and MINDSSC) in IO stage.